### PR TITLE
Call shutdown() instead of terminate()

### DIFF
--- a/mpi_learn/mpi/manager.py
+++ b/mpi_learn/mpi/manager.py
@@ -366,8 +366,8 @@ class MPIManager(object):
             print ("holding on",self.process.process_comm.Get_size())
             self.process.process_comm.Barrier()
             import horovod.common as hrv
-            print ("terminating hrv")
-            hrv.terminate()        
+            print ("Shutting down Horovod")
+            hrv.shutdown()
         if self.comm_block is not None:
             self.comm_block.Free()
         if self.comm_masters is not None:


### PR DESCRIPTION
Uber devs want to rename `terminate()` to `shutdown()`. Requires latest code from [multi_comm](https://github.com/vloncar/horovod/tree/multi_comm) Horovod branch.