### PR TITLE
Adam implementation in tensorflow

### DIFF
--- a/MPIDriver.py
+++ b/MPIDriver.py
@@ -180,6 +180,7 @@ if __name__ == '__main__':
         manager.process.record_details(json_name,
                                        meta={"args":vars(args)})            
         print ("Wrote trial information to {0}".format(json_name))
+        manager.process.algo.optimizer.close()
 
     comm.barrier()
     if args.trace: Trace.collect(clean=True)

--- a/MPIDriver.py
+++ b/MPIDriver.py
@@ -180,7 +180,6 @@ if __name__ == '__main__':
         manager.process.record_details(json_name,
                                        meta={"args":vars(args)})            
         print ("Wrote trial information to {0}".format(json_name))
-        manager.process.algo.optimizer.close()
 
     comm.barrier()
     if args.trace: Trace.collect(clean=True)

--- a/mpi_learn/train/algo.py
+++ b/mpi_learn/train/algo.py
@@ -160,4 +160,4 @@ class Algo(object):
             self.optimizer.save(fn)
 
     def load(self, fn):
-        self.optimizer.load(fn)
+        self.optimizer = self.optimizer.load(fn)

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -142,6 +142,7 @@ class AdamTF(Optimizer):
         if fn is None:
             fn = 'master-opt-{}.algo'.format( os.getpid())
         print ("Can't save AdamTF - file %s" % fn)
+        #TODO
     
     def reset(self):
         import tensorflow as tf
@@ -201,11 +202,6 @@ class AdamTF(Optimizer):
         Trace.end("tf_get_weights")
 
         return res
-    
-    def close(self):
-        if self.sess:
-            self.sess.close()
-
 
 class Adam(RunningAverageOptimizer):
     """Adam optimizer.

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -137,6 +137,12 @@ class AdamTF(Optimizer):
         self.t = 0
 
         self.reset()
+
+    def save(self, fn = None):
+        if fn is None:
+            fn = 'master-opt-{}.algo'.format( os.getpid())
+        print ("Can't save AdamTF - file %s" % fn)
+        #TODO
     
     def reset(self):
         if self.sess:

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -31,8 +31,9 @@ class Optimizer(object):
 
     def load(self, fn = 'algo_.pkl'):
         d = open(fn, 'rb')
-        self = pickle.load( d )
+        new_self = pickle.load( d )
         d.close()
+        return new_self
 
 
 class MultiOptimizer(Optimizer):

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -4,7 +4,6 @@ import numpy as np
 import copy
 import pickle
 import os
-import tensorflow as tf
 from ..train.trace import Trace, trace
 
 from ..utils import weights_from_shapes
@@ -145,6 +144,8 @@ class AdamTF(Optimizer):
         print ("Can't save AdamTF - file %s" % fn)
     
     def reset(self):
+        import tensorflow as tf
+
         if self.sess:
             self.sess.close() #free resources from previous execution
 
@@ -153,6 +154,8 @@ class AdamTF(Optimizer):
 
         
     def setup_update(self, weights):
+        import tensorflow as tf
+
         """Setup the tf computational graph. Should be run once for each model
             Receives the weights in order to know the shapes to use
         """
@@ -180,6 +183,8 @@ class AdamTF(Optimizer):
         )
     
     def apply_update(self, weights, gradient):
+        import tensorflow as tf
+
         if self.do_reset:
             self.setup_update(weights)
             self.sess.run(tf.global_variables_initializer())

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -143,7 +143,6 @@ class AdamTF(Optimizer):
         if fn is None:
             fn = 'master-opt-{}.algo'.format( os.getpid())
         print ("Can't save AdamTF - file %s" % fn)
-        #TODO
     
     def reset(self):
         if self.sess:
@@ -197,6 +196,11 @@ class AdamTF(Optimizer):
         Trace.end("tf_get_weights")
 
         return res
+    
+    def close(self):
+        if self.sess:
+            self.sess.close()
+
 
 class Adam(RunningAverageOptimizer):
     """Adam optimizer.

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -177,6 +177,7 @@ class AdamTF(Optimizer):
         if self.do_reset:
             self.setup_update(weights)
             self.sess.run(tf.initialize_all_variables()) #FIXME deprecated
+            self.do_reset = False
 
         gradient_dict = {placeholder: value for placeholder, value in zip(self.gradient, gradient)}
 

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -142,7 +142,6 @@ class AdamTF(Optimizer):
         if fn is None:
             fn = 'master-opt-{}.algo'.format( os.getpid())
         print ("Can't save AdamTF - file %s" % fn)
-        #TODO
     
     def reset(self):
         import tensorflow as tf

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -182,7 +182,7 @@ class AdamTF(Optimizer):
     def apply_update(self, weights, gradient):
         if self.do_reset:
             self.setup_update(weights)
-            self.sess.run(tf.initialize_all_variables()) #FIXME deprecated
+            self.sess.run(tf.global_variables_initializer())
             self.do_reset = False
 
         gradient_dict = {placeholder: value for placeholder, value in zip(self.gradient, gradient)}


### PR DESCRIPTION
Adds a new optimizer, **not selected by default**, implementing Adam in tensorflow.

In the tests with cifar10, this implementation is ~10x faster than the original Adam with numpy, and ~3x faster than numexpr.

In some executions, when running with pytorch, a generic error will be raised:
`RuntimeError: cublas runtime error : library not initialized at /pytorch/torch/lib/THC/THCGeneral.c:405`
This will happen, for example, if other processes are using the same gpu, and seems to be linked with lack of available resources.
This should not happen in a regular execution. It only happens in some executions using pytorch.

At the moment, the Adam tensorflow implementation cannot be saved/loaded from file.
Trivially using pickle on the object raises errors. It should be possible to export and import, using tensorflow's own load/save api or accessing the tf variables used, however it may take some time to properly implement.