### PR TITLE
Fix Horovod initialization (due to API change)

### DIFF
--- a/mpi_learn/mpi/manager.py
+++ b/mpi_learn/mpi/manager.py
@@ -388,9 +388,12 @@ class MPIManager(object):
         if self.process.process_comm is not None:
             print ("holding on",self.process.process_comm.Get_size())
             self.process.process_comm.Barrier()
-            import horovod.common as hrv
+            if self.model_builder.get_backend_name() == 'pytorch':
+                import horovod.torch as hvd
+            else:
+                import horovod.keras as hvd
             print ("Shutting down Horovod")
-            hrv.shutdown()
+            hvd.shutdown()
         if self.comm_block is not None:
             self.comm_block.Free()
         if self.comm_masters is not None:

--- a/mpi_learn/mpi/process.py
+++ b/mpi_learn/mpi/process.py
@@ -83,7 +83,10 @@ class MPIProcess(object):
         self.monitor = Monitor() if monitor else None
 
         if self.process_comm is not None and self.process_comm.Get_size() > 1:
-            import horovod.common as hvd
+            if self.model_builder.get_backend_name() == 'pytorch':
+                import horovod.torch as hvd
+            else:
+                import horovod.keras as hvd
             print ("initializing horovod")
             self.process_comm.Barrier()
             hvd.init(comm=self.process_comm)

--- a/mpi_learn/train/model.py
+++ b/mpi_learn/train/model.py
@@ -329,7 +329,8 @@ class MPITModel(MPIModel):
             
 class ModelBuilder(object):
     """Class containing instructions for building neural net models.
-        Derived classes should implement the build_model function.
+        Derived classes should implement the build_model and get_backend_name
+        functions.
 
         Attributes:
             comm: MPI communicator containing all running MPI processes
@@ -347,6 +348,10 @@ class ModelBuilder(object):
 
     def build_model(self):
         """Should return an uncompiled Keras model."""
+        raise NotImplementedError
+
+    def get_backend_name(self):
+        """Should return the name of backend framework."""
         raise NotImplementedError
 
 class ModelFromJson(ModelBuilder):
@@ -371,6 +376,9 @@ class ModelFromJson(ModelBuilder):
             return MPIModel(models = models)
         else:        
             return MPIModel(model=load_model(filename=self.filename, json_str=self.json_str, custom_objects=self.custom_objects, weights_file=self.weights))
+
+    def get_backend_name(self):
+        return 'keras'
 
 class ModelFromJsonTF(ModelBuilder):
     """ModelBuilder class that builds from model architecture specified
@@ -450,6 +458,8 @@ class ModelFromJsonTF(ModelBuilder):
                     per_process_gpu_memory_fraction=1./self.comm.Get_size()) ) ) )
             return self.build_model_aux()
 
+    def get_backend_name(self):
+        return 'tensorflow'
 
 class ModelPytorch(ModelBuilder):
     def __init__(self, comm, filename=None,
@@ -468,4 +478,7 @@ class ModelPytorch(ModelBuilder):
             wd = torch.load(self.weights)
             model.load_state_dict(wd)
         return MPITModel(model=model, gpus=self.gpus)
+
+    def get_backend_name(self):
+        return 'pytorch'
                                                         


### PR DESCRIPTION
Horovod changed the API slightly so it is no longer possible to directly call `init()` from `horovod.common` in latest version and we should instead use `init()` from proper backend, `horovod.keras` or `horovod.torch`. Importing the proper backand  instead of `horovod.common` is recommended approach and was available in previous versions, so with this change we remain compatible with older versions. 